### PR TITLE
Properly dispose of bootstrap once the application is killed

### DIFF
--- a/Runtime/Bootstrap/AbstractBootstrap.cs
+++ b/Runtime/Bootstrap/AbstractBootstrap.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -45,6 +46,11 @@ namespace Frame.Runtime.Bootstrap
             _canvasList = FetchActiveCanvases();
             
             await SceneWillLoad();
+        }
+
+        private void OnApplicationQuit()
+        {
+            OnBootstrapStop();
         }
 
         public virtual void OnBootstrapStop()

--- a/Runtime/Scene/AsyncScene.cs
+++ b/Runtime/Scene/AsyncScene.cs
@@ -153,6 +153,14 @@ namespace Frame.Runtime.Scene
                 }
             }
         }
+
+        /// <summary>
+        /// Explicitly unload the scene if this handle gets destroyed
+        /// </summary>
+        private async void OnDestroy()
+        {
+            await Unload();
+        }
     }
 
     public partial class AsyncScene: IAsyncScene


### PR DESCRIPTION
This helps editor logic.
