### PR TITLE
Add an abstract canvas

### DIFF
--- a/Runtime/Canvas/AbstractCanvas.cs
+++ b/Runtime/Canvas/AbstractCanvas.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Frame.Runtime.Canvas
+{
+    public class AbstractCanvas: MonoBehaviour, ICanvas
+    {
+        public virtual Task SceneWillUnloadAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual Task SceneWillLoadAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Runtime/Canvas/AbstractCanvas.cs.meta
+++ b/Runtime/Canvas/AbstractCanvas.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0adea02677f94a7ba5464cd456395f0b
+timeCreated: 1741816024


### PR DESCRIPTION
This changes allows you to extend from `AbstractCanvas`, which in turn is an `ICanvas`. This saves you to implement the `OnSceneWillLoad` and `OnSceneWillUnload` every time