### PR TITLE
Adds npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js & Configure Auth
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://packages.goreng.dev
+          always-auth: true
+          token: ${{ secrets.NPM_TOKEN }}
+          
+      - name: Publish package
+        run: npm publish --registry https://packages.goreng.dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Sets up a GitHub workflow to automatically publish the package to the Goreng registry on release creation.

- Configures Node.js environment with necessary authentication.
- Publishes the package using the provided NPM token.